### PR TITLE
OpenShift compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8
 
 WORKDIR /usr/src/app
+RUN chmod g+w /usr/src/app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Allow write access for root group to the app directory. Required for the database file.