### PR TITLE
HP-386 Add sonar project properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=example-backend-profile
+sonar.organization=city-of-helsinki
+
+sonar.sources=.
+sonar.tests=.
+
+sonar.test.inclusions=**/tests/**
+sonar.exclusions=**/tests/**


### PR DESCRIPTION
In out python projects, there is some additional trickery
involved in specifying which files are test files and which are actual
source code, since they don't exist in disjoint paths in the
filesystem tree.

Sonar includes some sane opinions as to which quality issues
are relevant for tests and which are not.

This configuration seems to work, where both sources and tests
are specified as identical and the tests are excluded separately
via a pattern (and then included again as tests).

Source
https://stackoverflow.com/questions/29101258