### PR TITLE
Make Django notice when behind a secure reverse proxy

### DIFF
--- a/example_backend_profile/settings.py
+++ b/example_backend_profile/settings.py
@@ -34,6 +34,7 @@ if DEBUG and not SECRET_KEY:
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 


### PR DESCRIPTION
Django is used to generate some absolute URLs, at least by social auth, which generates redirect URLs to be used in the OIDC flow. The scheme is included in the URLs and it needs to be correct. If the service is supposed to be accessed using https (only), then the scheme in the URLs must be https. If the service is behind a proxy that terminates TLS, then Django might not realize that traffic should use https.

Observing the request's headers can help. With this setting Django checks the X-Forwarded-Proto header and if its value is `https`, then the generated URLs will also have https scheme in them.

https://docs.djangoproject.com/en/3.2/ref/settings/#secure-proxy-ssl-header