### PR TITLE
Serve static files also when DEBUG=False

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 
 ./manage.py migrate --noinput
 
-./manage.py runserver 0.0.0.0:8000
+./manage.py runserver --insecure 0.0.0.0:8000


### PR DESCRIPTION
The container image uses the development server. The `staticfiles` app serves the static files, if `DEBUG` setting is `True`. In order to make it serve static files also when debug mode is not enabled, the `--insecure` flag can be used.

https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#runserver